### PR TITLE
feat: Adicionar propriedade de slug ao objeto de post

### DIFF
--- a/server/api/app/blog/post/[slugOrId].get.js
+++ b/server/api/app/blog/post/[slugOrId].get.js
@@ -81,6 +81,7 @@ export default defineEventHandler(async (event) => {
 		data: {
 			...post.get({ plain: true }),
 			category: post.get('category'),
+			slug: post.get('slug'),
 		},
 	};
 });


### PR DESCRIPTION
Essa alteração adiciona a propriedade de slug ao objeto de post retornado ao obter os detalhes do post. Isso melhora a funcionalidade do sistema, permitindo que o slug do post seja acessado diretamente no front-end.