### PR TITLE
feat: Ordenar postagens de blog por data de criação em ordem decrescente

### DIFF
--- a/server/api/app/blog/posts/index.get.js
+++ b/server/api/app/blog/posts/index.get.js
@@ -3,6 +3,7 @@ import { Blog } from '../../../../models/Blog.model';
 
 export default defineEventHandler(async () => {
 	const posts = await Blog.Post.findAll({
+		order: [['createdAt', 'DESC']],
 		attributes: ['id', 'slug', 'title', 'subtitle', 'content', 'image', 'video', 'createdAt', 'createdAtFull', 'views',
 			[Sequelize.literal('(SELECT COUNT(*) FROM `blog_likes` WHERE `blog_likes`.`blogPostId` = `blog_posts`.`id`)'), 'likeCount'], // get like count for each post
 			[Sequelize.literal('(SELECT `name` FROM `blog_categories` WHERE `blog_categories`.`id` = `blog_posts`.`blogCategoryId`)'), 'category'] // get category name for each post


### PR DESCRIPTION
Ordenar as postagens de blog por data de criação em ordem decrescente para exibir as postagens mais recentes primeiro. Isso melhora a experiência do usuário ao mostrar o conteúdo mais recente no topo e manter o blog atualizado.